### PR TITLE
fix: simple auth for frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ data/
 
 # Process management
 .web-cli.pid
+.web-cli-credentials

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -45,11 +45,11 @@ func (s *Server) setupRoutes() {
 	// Load auth configuration
 	authConfig := middleware.LoadAuthConfig()
 
+	// Apply authentication middleware to ALL routes (frontend + API)
+	s.router.Use(middleware.BasicAuth(authConfig))
+
 	// API routes
 	api := s.router.PathPrefix("/api").Subrouter()
-
-	// Apply authentication middleware to all API routes
-	api.Use(middleware.BasicAuth(authConfig))
 
 	// Health endpoint (authenticated)
 	api.HandleFunc("/health", s.handleHealth).Methods("GET")
@@ -94,9 +94,9 @@ func (s *Server) setupRoutes() {
 
 	// Log auth status
 	if authConfig.Enabled {
-		log.Println("API authentication is ENABLED")
+		log.Println("Authentication is ENABLED for entire application (frontend + API)")
 	} else {
-		log.Println("WARNING: API authentication is DISABLED (set AUTH_ENABLED=true for production)")
+		log.Println("WARNING: Authentication is DISABLED (set AUTH_ENABLED=true for production)")
 	}
 
 	// Serve static files from frontend build


### PR DESCRIPTION
### Added
- **Auto-generated test credentials** in `manage.sh` for easier local development
  - Generates random 22-character password using `openssl rand -base64 16`
  - Credentials saved to `.web-cli-credentials` file with usage examples
  - Credentials displayed on screen when server starts
  - Automatic cleanup when server stops
- Added `.web-cli-credentials` to `.gitignore`

### Changed
- **Authentication scope expanded** - Now protects entire application (frontend + API)
  - Previously: Only API routes required authentication
  - Now: Frontend static files also require authentication
  - Browser login dialog appears immediately when accessing the app
- Enhanced `manage.sh` with credential management
  - `start` command generates and displays credentials
  - `status` command shows credentials file location
  - `stop` command cleans up credentials file
- Updated server logging to indicate "entire application (frontend + API)" is protected

### Fixed
- **CRITICAL**: Frontend authentication bypass fixed
  - Frontend static files (HTML/JS/CSS) now require authentication
  - Users can no longer access the UI without logging in

### Security
- **Browser login prompt enforced** - No access to application without authentication
- **Random password generation** - 22-character passwords for testing environment
- **Credentials management** - Test credentials auto-generated and cleaned up properly