### PR TITLE
fix: healthchecks

### DIFF
--- a/API.md
+++ b/API.md
@@ -113,19 +113,24 @@ export AUTH_API_TOKEN="your-api-token-here"
 
 **HTTP Basic Auth:**
 ```bash
-curl -u admin:password http://localhost:7777/api/health
+curl -u admin:password http://localhost:7777/api/keys
 ```
 
 **Bearer Token:**
 ```bash
-curl -H "Authorization: Bearer your-token" http://localhost:7777/api/health
+curl -H "Authorization: Bearer your-token" http://localhost:7777/api/keys
 ```
+
+### Unauthenticated Endpoints
+
+The `/api/health` endpoint is exempt from authentication to allow Docker health checks, Kubernetes probes, and load balancer monitoring to work without credentials.
 
 ### Security Features
 - Constant-time credential comparison (prevents timing attacks)
 - Supports both Basic Auth and Bearer token simultaneously
 - Bearer token takes precedence if both are provided
 - bcrypt password hashing for stored credentials
+- Health endpoint excluded from auth for container orchestration compatibility
 
 **Note**: In production environments, always enable authentication and use HTTPS.
 
@@ -135,9 +140,11 @@ curl -H "Authorization: Bearer your-token" http://localhost:7777/api/health
 
 ### Get Server Health Status
 
-Check if the server is running and responsive.
+Check if the server is running and responsive. This endpoint does **not** require authentication, making it suitable for Docker health checks, Kubernetes probes, and load balancer health monitoring.
 
 **Endpoint**: `GET /health`
+
+**Authentication**: None required
 
 **Response**: `200 OK`
 
@@ -150,7 +157,11 @@ Check if the server is running and responsive.
 **Example**:
 
 ```bash
+# No authentication needed
 curl http://localhost:7777/api/health
+
+# Also works with HTTPS when TLS is enabled
+curl -k https://localhost:7777/api/health
 ```
 
 ---

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,8 +94,12 @@ WORKDIR /app
 # Copy binary from builder
 COPY --from=go-builder /app/web-cli /app/web-cli
 
+# Copy healthcheck script
+COPY scripts/healthcheck.sh /app/healthcheck.sh
+
 # Set ownership
-RUN chown webcli:webcli /app/web-cli
+RUN chown webcli:webcli /app/web-cli /app/healthcheck.sh && \
+    chmod +x /app/healthcheck.sh
 
 # Switch to non-root user
 USER webcli
@@ -103,9 +107,9 @@ USER webcli
 # Expose default port
 EXPOSE 7777
 
-# Health check using curl
+# Health check using script (auto-detects http/https based on TLS config)
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-    CMD curl -sf http://localhost:7777/api/health || exit 1
+    CMD ["/app/healthcheck.sh"]
 
 # Environment variables with defaults
 # Note: WEBCLI_ENCRYPTION_KEY_PATH is a file path to the key file, not the secret itself

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,7 +96,7 @@ services:
       # CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-}
 
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:7777/api/health"]
+      test: ["CMD", "/app/healthcheck.sh"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -47,27 +47,41 @@ export AUTH_API_TOKEN="your-api-token-here"
 - Supports both methods simultaneously (token takes precedence)
 - **Startup validation**: Server fails fast if auth is enabled but credentials are missing
 
+### Unauthenticated Endpoints
+
+The following endpoints are exempt from authentication to support container health checks and orchestration probes:
+
+| Endpoint | Purpose |
+|----------|---------|
+| `/api/health` | Health check for Docker/Kubernetes probes |
+
 ### Usage Examples
 
 ```bash
-# Basic Auth
-curl -u admin:password http://localhost:7777/api/health
+# Health check (no auth required)
+curl http://localhost:7777/api/health
 
-# Bearer Token
-curl -H "Authorization: Bearer your-token" http://localhost:7777/api/health
+# Basic Auth (required for all other endpoints)
+curl -u admin:password http://localhost:7777/api/keys
+
+# Bearer Token (required for all other endpoints)
+curl -H "Authorization: Bearer your-token" http://localhost:7777/api/keys
 ```
 
 ### Testing Authentication
 
 ```bash
-# Should fail (401 Unauthorized)
+# Health endpoint - always succeeds (no auth required)
 curl http://localhost:7777/api/health
 
+# Other endpoints - should fail without auth (401 Unauthorized)
+curl http://localhost:7777/api/keys
+
 # Should succeed with Basic Auth
-curl -u admin:password http://localhost:7777/api/health
+curl -u admin:password http://localhost:7777/api/keys
 
 # Should succeed with Bearer token
-curl -H "Authorization: Bearer your-token" http://localhost:7777/api/health
+curl -H "Authorization: Bearer your-token" http://localhost:7777/api/keys
 ```
 
 ---

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -832,6 +832,26 @@ const docTemplate = `{
                 }
             }
         },
+        "/health": {
+            "get": {
+                "description": "Check if the server is running and responsive. This endpoint does not require authentication.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System"
+                ],
+                "summary": "Health check",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_server.HealthResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/history": {
             "get": {
                 "security": [
@@ -3837,6 +3857,16 @@ const docTemplate = `{
                 "error": {
                     "type": "string",
                     "example": "Invalid request body"
+                }
+            }
+        },
+        "internal_server.HealthResponse": {
+            "description": "Health check response",
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "example": "ok"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -826,6 +826,26 @@
                 }
             }
         },
+        "/health": {
+            "get": {
+                "description": "Check if the server is running and responsive. This endpoint does not require authentication.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System"
+                ],
+                "summary": "Health check",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_server.HealthResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/history": {
             "get": {
                 "security": [
@@ -3831,6 +3851,16 @@
                 "error": {
                     "type": "string",
                     "example": "Invalid request body"
+                }
+            }
+        },
+        "internal_server.HealthResponse": {
+            "description": "Health check response",
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "example": "ok"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -656,6 +656,13 @@ definitions:
         example: Invalid request body
         type: string
     type: object
+  internal_server.HealthResponse:
+    description: Health check response
+    properties:
+      status:
+        example: ok
+        type: string
+    type: object
   internal_server.ShellInfo:
     description: Information about an available shell
     properties:
@@ -1206,6 +1213,20 @@ paths:
       summary: List all environment variable groups
       tags:
       - Environment Variables
+  /health:
+    get:
+      description: Check if the server is running and responsive. This endpoint does
+        not require authentication.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/internal_server.HealthResponse'
+      summary: Health check
+      tags:
+      - System
   /history:
     get:
       consumes:

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -13,10 +13,11 @@ var ErrAuthMisconfigured = errors.New("authentication is enabled but no credenti
 
 // AuthConfig holds authentication configuration
 type AuthConfig struct {
-	Enabled  bool
-	Username string
-	Password string
-	APIToken string
+	Enabled      bool
+	Username     string
+	Password     string
+	APIToken     string
+	ExcludePaths []string // Paths exempt from authentication (e.g., /api/health)
 }
 
 // LoadAuthConfig loads authentication configuration from environment
@@ -59,6 +60,14 @@ func BasicAuth(config *AuthConfig) func(http.Handler) http.Handler {
 			if !config.Enabled {
 				next.ServeHTTP(w, r)
 				return
+			}
+
+			// Skip auth for excluded paths (e.g., health checks)
+			for _, path := range config.ExcludePaths {
+				if r.URL.Path == path {
+					next.ServeHTTP(w, r)
+					return
+				}
 			}
 
 			// Check for API token first (Bearer token in Authorization header)

--- a/scripts/healthcheck.sh
+++ b/scripts/healthcheck.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euo pipefail
+
+# healthcheck.sh - Docker/container health check script for web-cli
+#
+# Determines the correct scheme (http/https) based on TLS configuration
+# and checks the /api/health endpoint. The health endpoint does not
+# require authentication.
+#
+# Environment variables used:
+#   WEBCLI_PORT           - Port the server listens on (default: 7777)
+#   WEBCLI_TLS_CERT_PATH  - TLS certificate path (if set, uses https)
+#   WEBCLI_TLS_KEY_PATH   - TLS key path (if set, uses https)
+#   TLS_CERT_PATH         - Alternative TLS cert path env var
+#   TLS_KEY_PATH          - Alternative TLS key path env var
+
+readonly PORT="${WEBCLI_PORT:-7777}"
+
+# Determine scheme based on TLS configuration
+# Check both WEBCLI_TLS_* and TLS_* env vars (server accepts both)
+CERT_PATH="${WEBCLI_TLS_CERT_PATH:-${TLS_CERT_PATH:-}}"
+KEY_PATH="${WEBCLI_TLS_KEY_PATH:-${TLS_KEY_PATH:-}}"
+
+if [[ -n "${CERT_PATH}" && -n "${KEY_PATH}" ]]; then
+    SCHEME="https"
+else
+    SCHEME="http"
+fi
+
+readonly URL="${SCHEME}://localhost:${PORT}/api/health"
+
+# Use -k to accept self-signed certificates in TLS mode
+if [[ "${SCHEME}" == "https" ]]; then
+    exec curl -sfk "${URL}"
+else
+    exec curl -sf "${URL}"
+fi


### PR DESCRIPTION
# Fix Docker Healthcheck with Authentication & TLS

Closes #15

## Fixed

- **Docker healthcheck fails when authentication is enabled** - The `/api/health` endpoint was behind the authentication middleware, causing Docker health probes to receive `401 Unauthorized` when `AUTH_ENABLED=true`. The health endpoint is now exempt from authentication, following industry best practices for container orchestration.
- **Docker healthcheck fails when TLS is enabled** - The healthcheck command was hardcoded to `http://`, causing TLS handshake errors when HTTPS was configured. A new `healthcheck.sh` script auto-detects TLS configuration from environment variables and uses the correct scheme.

## Changed

### Backend
- Added `ExcludePaths` support to the authentication middleware (`internal/middleware/auth.go`) - allows specific paths to bypass authentication
- Registered `/api/health` as an excluded path in route setup (`internal/server/server.go`)
- Added Swagger annotations for the health endpoint (was previously undocumented in Swagger UI)

### Docker
- New `scripts/healthcheck.sh` - TLS-aware healthcheck script that reads `WEBCLI_TLS_CERT_PATH` / `TLS_CERT_PATH` environment variables to determine `http` vs `https` scheme
- Updated `Dockerfile` to copy and use `healthcheck.sh` instead of inline `curl` command
- Updated `docker-compose.yml` to use `/app/healthcheck.sh` for health checks

### Documentation
- Updated `API.md` - health endpoint now documented as not requiring authentication
- Updated `docs/SECURITY.md` - added "Unauthenticated Endpoints" section listing exempt paths
- Regenerated Swagger spec (`docs/swagger.json`, `docs/swagger.yaml`) with health endpoint

## Testing

- 6 new tests added covering the fix:
  - `TestBasicAuth_ExcludedPaths` - verifies excluded paths bypass auth
  - `TestBasicAuth_ExcludedPathsEmpty` - verifies nil exclusions still require auth
  - `TestBasicAuth_ExcludedPathsMultiple` - verifies multiple paths can be excluded
  - `TestHandleHealth` - basic health handler response test
  - `TestHandleHealth_NoAuthRequired` - full routing integration test with auth middleware
- All existing tests continue to pass
- Docker end-to-end tested: container reports `healthy` with `AUTH_ENABLED=true`
- Race detector clean (`go test -race ./...`)
- Shellcheck clean on `healthcheck.sh`

## Security Notes

- Only the `/api/health` endpoint is exempt from authentication
- The health endpoint returns only `{"status":"ok"}` - no sensitive information is exposed
- All other API endpoints continue to require authentication when `AUTH_ENABLED=true`
- The `ExcludePaths` mechanism uses exact path matching (no wildcards) to prevent accidental bypasses
